### PR TITLE
Update: 細かな調整

### DIFF
--- a/Assets/Resource/Player/ScriptableDatas/PlayerDatas/PD_SaotomeKurumi.asset
+++ b/Assets/Resource/Player/ScriptableDatas/PlayerDatas/PD_SaotomeKurumi.asset
@@ -16,5 +16,5 @@ MonoBehaviour:
   characterAnimData: {fileID: 11400000, guid: 0b10f1572d2f39c4fa2e3a93f1d0961b, type: 2}
   moveSpeed: 5
   shell: {fileID: 11400000, guid: 74998d58e3c668641a22ecfb124d6544, type: 2}
-  subWeapon: {fileID: 11400000, guid: a883619b242c3154f89ca4828f58990d, type: 2}
+  subWeapon: {fileID: 11400000, guid: 450e1038afe7aa1439c3da768170fae2, type: 2}
   playerSFXData: {fileID: 11400000, guid: a594c46fc7684f847a520d6e099ab3c9, type: 2}

--- a/Assets/Resource/Player/ScriptableDatas/PlayerDatas/PD_ToshimaNanami.asset
+++ b/Assets/Resource/Player/ScriptableDatas/PlayerDatas/PD_ToshimaNanami.asset
@@ -16,5 +16,5 @@ MonoBehaviour:
   characterAnimData: {fileID: 11400000, guid: 203b2e40b2be78a43bb9721dc3f741a1, type: 2}
   moveSpeed: 5
   shell: {fileID: 11400000, guid: f634eb2d53fef924da4f41d1fe258b13, type: 2}
-  subWeapon: {fileID: 11400000, guid: 450e1038afe7aa1439c3da768170fae2, type: 2}
+  subWeapon: {fileID: 11400000, guid: a883619b242c3154f89ca4828f58990d, type: 2}
   playerSFXData: {fileID: 11400000, guid: a594c46fc7684f847a520d6e099ab3c9, type: 2}

--- a/Assets/Resource/Player/ScriptableDatas/PlayerSFXData/PSD_Chikane.asset
+++ b/Assets/Resource/Player/ScriptableDatas/PlayerSFXData/PSD_Chikane.asset
@@ -16,4 +16,4 @@ MonoBehaviour:
   aimSFX: {fileID: 8300000, guid: a394c1da9443a694b9b3a4e753b8ce8b, type: 3}
   fireSFX: {fileID: 8300000, guid: 37944658b33bfcb47afd6be7ae5e0241, type: 3}
   flySFX: {fileID: 0}
-  explosionSFX: {fileID: 8300000, guid: d651c0ab6c52d5d49b25b775997b64dd, type: 3}
+  explosionSFX: {fileID: 8300000, guid: ecbbe21c156166443bde1696f25bde5a, type: 3}

--- a/Assets/Resource/SoundObject/SoundObject.prefab
+++ b/Assets/Resource/SoundObject/SoundObject.prefab
@@ -66,7 +66,7 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1
   MinDistance: 1
-  MaxDistance: 500
+  MaxDistance: 1000
   Pan2D: 0
   rolloffMode: 0
   BypassEffects: 0

--- a/Assets/Scenes/IngameScene.unity
+++ b/Assets/Scenes/IngameScene.unity
@@ -442,7 +442,7 @@ Light:
     m_Type: 2
     m_Resolution: -1
     m_CustomResolution: -1
-    m_Strength: 1
+    m_Strength: 0.85
     m_Bias: 0.05
     m_NormalBias: 0.4
     m_NearPlane: 0.2
@@ -682,6 +682,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: SceneChangeEndCanvas
+      objectReference: {fileID: 0}
+    - target: {fileID: 3921321195368664648, guid: d9fa9ccc66faa99448ebba54949af122,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []


### PR DESCRIPTION
・Ingameのディレクショナルライトが作り出す影の値を1.0→0.85に調整
・サブ武器をくるみに地雷、七海にリロードビーコンを設定
・SoundObjectの範囲を調整