### PR TITLE
Update: キャラ調整

### DIFF
--- a/Assets/Resource/Player/ScriptableDatas/ExplosionDatas/ED_MiraiCanonExplosion.asset
+++ b/Assets/Resource/Player/ScriptableDatas/ExplosionDatas/ED_MiraiCanonExplosion.asset
@@ -14,5 +14,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   explosionBody: {fileID: 3179393461812120061, guid: 5fbefd8f387895448bc643a35cd119ea,
     type: 3}
-  scale: 4
+  scale: 3
   explosionAnim: {fileID: 9100000, guid: bbb5fe1cf956bdb48a5d8d9d2db2ce21, type: 2}

--- a/Assets/Resource/Player/ScriptableDatas/ShellDatas/SD_SaraProjectile.asset
+++ b/Assets/Resource/Player/ScriptableDatas/ShellDatas/SD_SaraProjectile.asset
@@ -25,4 +25,4 @@ MonoBehaviour:
   projectileSpeed: 0
   aimRange: 25
   aimDegree: 360
-  lifeTime: 2
+  lifeTime: 1.5

--- a/Assets/Resource/Player/Shell/Projectile/Koto/BackBlastCanonBehavior.cs
+++ b/Assets/Resource/Player/Shell/Projectile/Koto/BackBlastCanonBehavior.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public class BackBlastCanonBehavior : ProjectileBehavior
 {
+    [SerializeField] Explosion backBlastExplosion;
     const float backBlastTime = 0.25f;
     bool spawnedBackBlast;
 
@@ -23,12 +24,12 @@ public class BackBlastCanonBehavior : ProjectileBehavior
 
     void SpawnBackBlast()
     {
-        float explosionRadius = explosion.GetScale() * 1.5f;
+        float explosionRadius = backBlastExplosion.GetScale() * 1.5f;
         Vector3 spawnPos = ownerPlayer.transform.position - transform.forward * explosionRadius;
 
-        GameObject obj = Instantiate(explosion.GetBody(), spawnPos, Quaternion.identity);
+        GameObject obj = Instantiate(backBlastExplosion.GetBody(), spawnPos, Quaternion.identity);
         obj.GetComponent<ExplosionBehavior>().SetPlayer(ownerPlayer);
-        obj.GetComponent<ExplosionBehavior>().SetData(explosion);
+        obj.GetComponent<ExplosionBehavior>().SetData(backBlastExplosion);
         spawnedBackBlast = true;
     }
 }

--- a/Assets/Resource/Player/Shell/Projectile/Koto/BackBlastCanonBehavior.cs.meta
+++ b/Assets/Resource/Player/Shell/Projectile/Koto/BackBlastCanonBehavior.cs.meta
@@ -3,7 +3,9 @@ guid: d4d2799aad5306d498eb34ff3458e70d
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
-  defaultReferences: []
+  defaultReferences:
+  - backBlastExplosion: {fileID: 11400000, guid: 7ee9dcac500346d4db8c4f141ba66fdd,
+      type: 2}
   executionOrder: 0
   icon: {instanceID: 0}
   userData: 

--- a/Assets/Resource/Player/Shell/Projectile/Koto/BackBlastProjectilePrefab.prefab
+++ b/Assets/Resource/Player/Shell/Projectile/Koto/BackBlastProjectilePrefab.prefab
@@ -69,6 +69,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d4d2799aad5306d498eb34ff3458e70d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  backBlastExplosion: {fileID: 11400000, guid: 7ee9dcac500346d4db8c4f141ba66fdd, type: 2}
 --- !u!1 &2008790680177907739
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resource/Player/Shell/Projectile/Koto/ED_KotoBackBlastExplosion.asset
+++ b/Assets/Resource/Player/Shell/Projectile/Koto/ED_KotoBackBlastExplosion.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7ea82a71e064af341b9c69f4636d1777, type: 3}
+  m_Name: ED_KotoBackBlastExplosion
+  m_EditorClassIdentifier: 
+  explosionBody: {fileID: 3179393461812120061, guid: 5fbefd8f387895448bc643a35cd119ea,
+    type: 3}
+  scale: 0.5
+  explosionAnim: {fileID: 9100000, guid: bbb5fe1cf956bdb48a5d8d9d2db2ce21, type: 2}

--- a/Assets/Resource/Player/Shell/Projectile/Koto/ED_KotoBackBlastExplosion.asset.meta
+++ b/Assets/Resource/Player/Shell/Projectile/Koto/ED_KotoBackBlastExplosion.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7ee9dcac500346d4db8c4f141ba66fdd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resource/Player/Shell/Projectile/Sara/ED_Fragment.asset
+++ b/Assets/Resource/Player/Shell/Projectile/Sara/ED_Fragment.asset
@@ -14,5 +14,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   explosionBody: {fileID: 3179393461812120061, guid: 5fbefd8f387895448bc643a35cd119ea,
     type: 3}
-  scale: 2
-  explosionAnim: {fileID: 9100000, guid: bbb5fe1cf956bdb48a5d8d9d2db2ce21, type: 2}
+  scale: 1.5
+  explosionAnim: {fileID: 9100000, guid: f476137a5f01e7243b5f2cea2279fd83, type: 2}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -137,8 +137,7 @@ PlayerSettings:
   vulkanEnableCommandBufferRecycling: 1
   loadStoreDebugModeEnabled: 0
   bundleVersion: 0.1.0
-  preloadedAssets:
-  - {fileID: 11400000, guid: 3119423baa5ed7440ae8e5d27b964d66, type: 2}
+  preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
Update: 沙羅の調整
・着弾を2.0sec→1.5sec
・散弾の爆発範囲を2.0→1.5に変更
Update: みらいの調整
・爆風範囲を4.0→3.0
Update: 琴の調整
・バックブラストの爆発範囲を1.5→0.5に変更
・飛翔体速度を9.0→12.0に変更
・飛翔体生存時間を1.0→0.6に変更