### PR TITLE
Update: サブ武器の調整

### DIFF
--- a/Assets/Resource/Player/ScriptableDatas/SubWeaponData/SW_Acceleration.asset
+++ b/Assets/Resource/Player/ScriptableDatas/SubWeaponData/SW_Acceleration.asset
@@ -20,6 +20,6 @@ MonoBehaviour:
   subWeaponExplain: "\uFF15\u79D2\u9593\u3001\u81EA\u8EAB\u306E\u79FB\u52D5\u901F\u5EA6\u304C\u4E0A\u6607\u3059\u308B\n\u4F7F\u7528\u5F8C\u300115\u79D2\u306E\u5F85\u6A5F\u6642\u9593\u304C\u5FC5\u8981"
   installationStartAnim: {fileID: 0}
   installationLoopAnim: {fileID: 0}
-  reloadTime: 25
+  reloadTime: 15
   speedRate: 1.5
   lifeTime: 5

--- a/Assets/Resource/Player/ScriptableDatas/SubWeaponData/SW_BlindSmokeBomb.asset
+++ b/Assets/Resource/Player/ScriptableDatas/SubWeaponData/SW_BlindSmokeBomb.asset
@@ -21,6 +21,6 @@ MonoBehaviour:
   subWeaponExplain: "10\u79D2\u6301\u7D9A\u3059\u308B\u7159\u5E55\u3092\u6295\u64F2\n15\u79D2\u9593\u8996\u754C\u304C\u60AA\u304F\u306A\u308B"
   installationStartAnim: {fileID: 0}
   installationLoopAnim: {fileID: 0}
-  reloadTime: 30
+  reloadTime: 20
   speedRate: 0.5
   lifeTime: 10

--- a/Assets/Resource/Player/ScriptableDatas/SubWeaponData/SW_BlueCoral.asset
+++ b/Assets/Resource/Player/ScriptableDatas/SubWeaponData/SW_BlueCoral.asset
@@ -23,6 +23,6 @@ MonoBehaviour:
     type: 2}
   installationLoopAnim: {fileID: 9100000, guid: ab12581ac6d1fa04c984951dbe8d22bd,
     type: 2}
-  reloadTime: 30
+  reloadTime: 20
   speedRate: 1.2
   lifeTime: 1

--- a/Assets/Resource/Player/ScriptableDatas/SubWeaponData/SW_Mine.asset
+++ b/Assets/Resource/Player/ScriptableDatas/SubWeaponData/SW_Mine.asset
@@ -23,6 +23,6 @@ MonoBehaviour:
     type: 2}
   installationLoopAnim: {fileID: 9100000, guid: f6859c366d2eafe449618c4ead980fb1,
     type: 2}
-  reloadTime: 25
+  reloadTime: 20
   speedRate: 0
   lifeTime: Infinity

--- a/Assets/Resource/Player/ScriptableDatas/SubWeaponData/SW_SpiderBomb.asset
+++ b/Assets/Resource/Player/ScriptableDatas/SubWeaponData/SW_SpiderBomb.asset
@@ -21,6 +21,6 @@ MonoBehaviour:
   subWeaponExplain: "10\u79D2\u6301\u7D9A\u3059\u308B\u8718\u86DB\u306E\u5DE3\u3092\u6295\u64F2\n\uFF15\u79D2\u9593\u79FB\u52D5\u901F\u5EA6\u304C\u6E1B\u5C11\u3059\u308B"
   installationStartAnim: {fileID: 0}
   installationLoopAnim: {fileID: 0}
-  reloadTime: 30
+  reloadTime: 20
   speedRate: 0.5
   lifeTime: 10

--- a/Assets/Resource/Player/ScriptableDatas/SubWeaponData/SW_TapiocaBomb.asset
+++ b/Assets/Resource/Player/ScriptableDatas/SubWeaponData/SW_TapiocaBomb.asset
@@ -18,9 +18,9 @@ MonoBehaviour:
   installation: {fileID: 3179393461812120061, guid: cf6d56e57f4cc8144a0fdcbe2574de49,
     type: 3}
   subWeaponName: "\u30BF\u30D4\u30AA\u30AB\u7206\u5F3E\n\u30BF\u30D4\u30AA\u30AB\u7206\u5F3E"
-  subWeaponExplain: "10\u79D2\u6301\u7D9A\u3059\u308B\u30BF\u30D4\u30AA\u30AB\u3092\u6295\u64F2\n\uFF18\u79D2\u9593\u8DB3\u304C\u6ED1\u308B\u3088\u3046\u306B\u306A\u308B"
+  subWeaponExplain: "10\u79D2\u6301\u7D9A\u3059\u308B\u30BF\u30D4\u30AA\u30AB\u3092\u6295\u64F2\n\uFF16\u79D2\u9593\u8DB3\u304C\u6ED1\u308B\u3088\u3046\u306B\u306A\u308B"
   installationStartAnim: {fileID: 0}
   installationLoopAnim: {fileID: 0}
-  reloadTime: 30
+  reloadTime: 20
   speedRate: 0.5
   lifeTime: 10

--- a/Assets/Resource/Player/ScriptableDatas/SubWeaponData/SW_TeenSpirit.asset
+++ b/Assets/Resource/Player/ScriptableDatas/SubWeaponData/SW_TeenSpirit.asset
@@ -24,6 +24,6 @@ MonoBehaviour:
     type: 2}
   installationLoopAnim: {fileID: 9100000, guid: ab12581ac6d1fa04c984951dbe8d22bd,
     type: 2}
-  reloadTime: 30
+  reloadTime: 15
   speedRate: 0.65
   lifeTime: 1

--- a/Assets/Resource/Player/SubWeapon/Bomb/TapiocaBomb/TapiocaExplosionBehavior.cs
+++ b/Assets/Resource/Player/SubWeapon/Bomb/TapiocaBomb/TapiocaExplosionBehavior.cs
@@ -36,6 +36,6 @@ public class TapiocaExplosionBehavior : ExplosionBehavior
         //トラップ被弾ボイスを鳴らす
         nowPlayer.PlayVoice(nowPlayer.GetPlayerData().GetPlayerVoiceData().GetDamageTrap(), Camera.main.transform);
 
-        nowPlayer.GetComponent<PlayerMove>().ReceiveSlip(12.0f);
+        nowPlayer.GetComponent<PlayerMove>().ReceiveSlip(6.0f);
     }
 }

--- a/Assets/Resource/Player/SubWeapon/Installation/BlueCoral/BlueCoralBehavior.cs
+++ b/Assets/Resource/Player/SubWeapon/Installation/BlueCoral/BlueCoralBehavior.cs
@@ -30,7 +30,7 @@ public class BlueCoralBehavior : InstallationBehavior
         TimeSetting();
 
         timer += deltaTime;
-        transform.localScale = Vector3.one * Mathf.Clamp01(timer / lifeTime) * 2;
+        transform.localScale = Vector3.one * Mathf.Clamp01(timer / lifeTime) * 3;
 
         if (timer > lifeTime) { Destroy(gameObject); }
     }

--- a/Assets/Resource/Player/SubWeapon/Installation/TeenSpirit/TeenSpiritBehavior.cs
+++ b/Assets/Resource/Player/SubWeapon/Installation/TeenSpirit/TeenSpiritBehavior.cs
@@ -30,7 +30,7 @@ public class TeenSpiritBehavior : InstallationBehavior
         TimeSetting();
 
         timer += deltaTime;
-        transform.localScale = Vector3.one * Mathf.Clamp01(timer / lifeTime) * 2;
+        transform.localScale = Vector3.one * Mathf.Clamp01(timer / lifeTime) * 3;
         if (timer > lifeTime) { Destroy(gameObject); }
     }
 


### PR DESCRIPTION
・タピオカの効果時間を12.0sec→6.0secに変更
・リキャストの上限を20secに統一
　アクセラレーション…15sec
　煙幕弾…20sec
　ブルーコーラル…20sec
　電磁スタン地雷…20sec
　スパイダー爆弾…20sec
　タピオカ爆弾…20sec
　ティーンスピリット…15sec